### PR TITLE
Feature/ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@1.4.0
+
+workflows:
+  tests:
+    jobs:
+      - python/test:
+          test-tool: pytest
+          matrix:
+            parameters:
+              version: ["3.6", "3.8", "3.9"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,3 +11,4 @@ workflows:
           matrix:
             parameters:
               version: ["3.6", "3.8", "3.9"]
+              args: ["&& pip install django==2.2", "&& pip install django==3.2",]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,3 +12,9 @@ workflows:
             parameters:
               version: ["3.6", "3.8", "3.9"]
               args: ["&& pip install django==2.2", "&& pip install django==3.2",]
+          post-steps:
+            - run: 
+                command: |
+                  black . --check
+                  python manage.py check
+                  python manage.py makemigrations --check

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ black==21.7b0
 isort
 ipdb
 django-pipeline==2.0.6
-Django==2.2.24
+Django>=2.2,<=3.2
 setuptools==57.0.0
 pre-commit
 djhtml

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
     django-pipeline == 2.0.6
     libsass == 0.21.0
     jsmin==2.2.2
-    django<3
+    django>=2.2,<=3.2
     pytest-django
     pytest
     pytidylib


### PR DESCRIPTION
Add circle ci config to run tests for python 3.6/3.8/3.9, Django 2.2/3.2. Uses circle ci python orb -  I feel like ultimately we might want to define the steps ourselves but for now this might suffice?

![Screenshot 2021-07-22 at 11 57 41](https://user-images.githubusercontent.com/15347726/126628898-cca8a771-4063-4862-9d1e-8355c69151e8.png)
