### PR TITLE
Feature/html test options

### DIFF
--- a/dc_utils/tests/helpers.py
+++ b/dc_utils/tests/helpers.py
@@ -7,5 +7,22 @@ def validate_html(client, url):
     """
     response = client.get(url)
     content = response.content
-    document, errors = tidy_document(content)
+    document, errors = tidy_document(
+        content,
+        options={
+            "indent": 1,  # Pretty; not too much of a performance hit
+            "tidy-mark": 0,  # No tidy meta tag in output
+            "wrap": 72,  # No wrapping
+            "alt-text": "",  # Help ensure validation
+            "force-output": 1,  # May not get what you expect but you will get something
+            "show-warnings": 0,
+            "show-errors": 1,
+            "ascii-chars": 1,
+            "accessibility-check": 0,  # This is something we may want to turn on once we sort all html failures
+            "show-body-only": 1,
+            "fix-uri": 0,
+            "mute-id": 1,
+            "show-filename": 1,
+        },
+    )
     return document, errors

--- a/dc_utils/tests/test_helpers.py
+++ b/dc_utils/tests/test_helpers.py
@@ -18,4 +18,21 @@ def test_validate_html(mocker):
 
     assert result == ("document", "errors")
     client.get.assert_called_once_with(url)
-    tidy_document.assert_called_once_with("html_content")
+    tidy_document.assert_called_once_with(
+        "html_content",
+        options={
+            "indent": 1,  # Pretty; not too much of a performance hit
+            "tidy-mark": 0,  # No tidy meta tag in output
+            "wrap": 72,  # No wrapping
+            "alt-text": "",  # Help ensure validation
+            "force-output": 1,  # May not get what you expect but you will get something
+            "show-warnings": 0,
+            "show-errors": 1,
+            "ascii-chars": 1,
+            "accessibility-check": 0,  # This is something we may want to turn on once we sort all html failures
+            "show-body-only": 1,
+            "fix-uri": 0,
+            "mute-id": 1,
+            "show-filename": 1,
+        },
+    )


### PR DESCRIPTION
This work adds [repair options](https://api.html-tidy.org/tidy/quickref_next.html) to `pytidylib`.