### PR TITLE
Upgrade/django 3.2

### DIFF
--- a/dc_utils/tests/test_urls.py
+++ b/dc_utils/tests/test_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.defaults import ERROR_500_TEMPLATE_NAME
 
 

--- a/dc_utils/urls.py
+++ b/dc_utils/urls.py
@@ -1,6 +1,6 @@
 from django import http
 from django.conf import settings
-from django.conf.urls import url
+from django.urls.re_path import re_path
 from django.template import TemplateDoesNotExist, loader
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME, page_not_found
@@ -30,8 +30,8 @@ def dc_server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
 
 
 urlpatterns = [
-    url(r"500.html$", dc_server_error),
-    url(r"404.html$", page_not_found, {"exception": "Fake problem"}),
+    re_path(r"500.html$", dc_server_error),
+    re_path(r"404.html$", page_not_found, {"exception": "Fake problem"}),
 ]
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ black==21.7b0
 isort
 ipdb
 django-pipeline==2.0.6
-Django>=2.2,<=3.2
+Django>=2.0,<3.3
 setuptools==57.0.0
 pre-commit
 djhtml


### PR DESCRIPTION
This work upgrades `dc-utils` to Django 3.2, updates site packages and addresses deprecation warnings. 