### PR TITLE
Fix bug where dc_form render called with a string

### DIFF
--- a/dc_utils/templatetags/dc_forms.py
+++ b/dc_utils/templatetags/dc_forms.py
@@ -24,6 +24,9 @@ def add_input_classes(field):
 
 @register.filter
 def dc_form(element):
+    if not isinstance(element, forms.Form):
+        # if called without a form object, return without rendering
+        return
     markup_classes = {"label": "", "value": "", "single_value": ""}
     return render(element, markup_classes)
 

--- a/dc_utils/tests/test_dc_forms.py
+++ b/dc_utils/tests/test_dc_forms.py
@@ -1,0 +1,22 @@
+import pytest
+from django import forms
+
+from dc_utils.templatetags.dc_forms import dc_form
+
+
+class TestDCForms:
+    def test_render_not_called_when_element_not_a_form(self, mocker):
+        mock_render = mocker.Mock()
+        mocker.patch("dc_utils.templatetags.dc_forms.render", mock_render)
+
+        assert dc_form(element="not_a_form") is None
+        mock_render.assert_not_called()
+
+    def test_render_called_when_element_is_a_form(self, mocker):
+        mock_render = mocker.Mock(return_value="rendered_form")
+        mocker.patch("dc_utils.templatetags.dc_forms.render", mock_render)
+        form = forms.Form()
+        assert dc_form(element=form) == "rendered_form"
+        mock_render.called_once_with(
+            form, {"label": "", "value": "", "single_value": ""}
+        )


### PR DESCRIPTION
- If the dc_form filter is passed a non-form object return early
- Fixes bug where it was being called with an empty string when a 500
error is raised, which caused the 500 page itself to fail to render

I still think it would be worth fixing this further by not having the 500 page extend from the projects `base.html`, as it was the attempt to render the mailing form on a 500 page that is the root cause of the error. However I'm not sure how best to go about this right now, for in the meantime this will resolve the error `AttributeError: 'str' object has no attribute 'visible_fields'` that was occurring in projects and suppressing the real error that was occurring from being raised