### PR TITLE
Hotfix/Remove staticfiles tag 

### DIFF
--- a/dc_utils/templates/500.html
+++ b/dc_utils/templates/500.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block page_title %}Server Error{% endblock %}
 


### PR DESCRIPTION
`staticfiles` is deprecated in favor of `static`. This change should address warnings in dependent code bases. 