### PR TITLE
Support patch versions  of Django 3.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
     django-pipeline == 2.0.6
     libsass == 0.21.0
     jsmin==3.0.0
-    django>=2.2,<=3.2
+    django>=2.2,<=3.3
     pytest-django
     pytest
     pytidylib


### PR DESCRIPTION
Before this change, it was impossible to install this package with a version of Django higher than 3.2.0 (e.g, patch versions).

This change allows all versions up to 3.3