### PR TITLE
Add markdown template tag

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@ isort
 ipdb
 django-pipeline==2.0.6
 Django>=2.0,<3.3
+markdown
 setuptools==57.0.0
 pre-commit
 djhtml


### PR DESCRIPTION
Following on from the work done [here](https://github.com/DemocracyClub/Website/pull/432), this addition will make the custom markdown template tag and filter available on all DC sites requiring `dc_utils'. 