### PR TITLE
Bump Django to <4.2

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ black==22.3.0
 isort
 ipdb
 django-pipeline==2.0.6
-Django>=3.2,<=4.0
+Django>=3.2,<4.2
 markdown
 setuptools==57.0.0
 pre-commit


### PR DESCRIPTION
Bump Django to `<4.2` to support EE upgrade