### PR TITLE
Bump django-pipeline 2.0.8

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 isort
 ipdb
-django-pipeline==2.0.6
+django-pipeline==2.0.8
 Django>=3.2,<4.2
 markdown
 setuptools==57.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ packages = find:
 include_package_data = true
 install_requires =
     whitenoise == 5.2.0
-    django-pipeline == 2.0.6
+    django-pipeline == 2.0.8
     libsass == 0.21.0
     jsmin==3.0.0
     django>=3.2,<4.2


### PR DESCRIPTION
Matches `django-pipeline 2.0.8` to solve dependency conflict with `dc_base_theme` in EE.