### PR TITLE
GBPostcode + base template tidy

### DIFF
--- a/dc_utils/forms.py
+++ b/dc_utils/forms.py
@@ -5,6 +5,18 @@ from django.core.exceptions import ValidationError
 
 from . import widgets
 
+from django.utils.translation import gettext_lazy as _
+from localflavor.gb.forms import GBPostcodeField
+
+
+class PostcodeLookupForm(forms.Form):
+    postcode = GBPostcodeField(label=_("Enter your postcode"))
+
+    def __init__(self, autofocus=False, *args, **kwargs):
+        super(PostcodeLookupForm, self).__init__(*args, **kwargs)
+        if autofocus:
+            self.fields["postcode"].widget.attrs["autofocus"] = "autofocus"
+
 
 class DCHeaderField(forms.Field):
     """
@@ -131,6 +143,7 @@ class SampleForm(forms.Form):
     clearable_file = forms.FileField(
         widget=forms.ClearableFileInput, required=False
     )
+    postcode_form = PostcodeLookupForm()
 
     def clean(self):
         super().clean()

--- a/dc_utils/forms.py
+++ b/dc_utils/forms.py
@@ -9,15 +9,6 @@ from django.utils.translation import gettext_lazy as _
 from localflavor.gb.forms import GBPostcodeField
 
 
-class PostcodeLookupForm(forms.Form):
-    postcode = GBPostcodeField(label=_("Enter your postcode"))
-
-    def __init__(self, autofocus=False, *args, **kwargs):
-        super(PostcodeLookupForm, self).__init__(*args, **kwargs)
-        if autofocus:
-            self.fields["postcode"].widget.attrs["autofocus"] = "autofocus"
-
-
 class DCHeaderField(forms.Field):
     """
     A field that is just rendered as a heading.
@@ -143,7 +134,8 @@ class SampleForm(forms.Form):
     clearable_file = forms.FileField(
         widget=forms.ClearableFileInput, required=False
     )
-    postcode_form = PostcodeLookupForm()
+
+    postcode = GBPostcodeField(label=_("Enter your postcode"))
 
     def clean(self):
         super().clean()

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -4,18 +4,16 @@
 {% block body_raw %}
     <body {% block body_attrs %}class="ds-width-full"{% endblock body_attrs %}>
         <div class="ds-page">
-            <p><a class="ds-skip-link" href="#main">skip to content</a></p>
-
+            <a class="ds-skip-link" href="#main">skip to content</a>
+            {% block base_language_menu %}{% endblock base_language_menu %}
             {% block header_base %}
-                <header role="banner">
-                    <div class="container">
-                        {% if site_logo %}
-                            <a href="/">
-                                <img src="{% static site_logo %}" alt="{{ site_title }}" width="{{ SITE_LOGO_WIDTH|default:"100" }}">
-                            </a>
-                        {% endif %}
-                        {% block site_menu %}{% endblock site_menu %}
-                    </div>
+                <header class="ds-header">
+                    <a class="ds-logo" href="/">
+                        <img src="{% static 'images/logo_icon.svg' %}" alt="{{ SITE_TITLE }}" width="{{ SITE_LOGO_WIDTH|default:"100" }}">
+                        <span>{{ SITE_TITLE }}</span>
+                        {% block language_code %}{% endblock language_code %}
+                    </a>
+                    {% block site_menu %}{% endblock site_menu %}
                 </header>
             {% endblock header_base %}
 

--- a/dc_utils/templates/dc_base_naked.html
+++ b/dc_utils/templates/dc_base_naked.html
@@ -43,7 +43,9 @@
                 <meta name="twitter:image" content="{% block twitter_image_url %}{{ CANONICAL_URL }}{% static 'images/og_image_logo.png' %}{% endblock twitter_image_url %}" />
                 <meta name="twitter:description" content="{% block twitter_description_content %}We build digital tools to support everyone’s participation in UK democracy.{% endblock twitter_description_content %}"/>
             {% endblock twitter_tags %}
-
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         {% endblock site_meta %}
     </head>
     {% block body_raw %}

--- a/dc_utils/templates/dc_forms/field.html
+++ b/dc_utils/templates/dc_forms/field.html
@@ -3,7 +3,7 @@
     {% if field|is_heading %}
         <h2>{{ field.label }}</h2>
     {% else %}
-        <label class="{{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{field.auto_id}}">
+        <label class="{{ classes.label }} {% if field.field.required %}aria-required="true"{% endif %}" for="{{field.auto_id}}">
             {{ field.label }}
             {% if field.help_text %}
                 <small>{{ field.help_text }}</small>

--- a/dc_utils/templates/dc_forms/field.html
+++ b/dc_utils/templates/dc_forms/field.html
@@ -1,6 +1,6 @@
 {% load dc_forms %}
 <div class="ds-field">
-    {% if not field|is_heading %}
+    {% if field|is_heading %}
         <h2>{{ field.label }}</h2>
     {% else %}
         <label class="{{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{field.auto_id}}">

--- a/dc_utils/templates/dc_forms/field.html
+++ b/dc_utils/templates/dc_forms/field.html
@@ -12,4 +12,3 @@
         {{ field }}
     {% endif %}
 </div>
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@ ipdb
 django-pipeline==2.0.8
 Django>=3.2,<4.2
 markdown
+django-localflavor==3.1
 setuptools==57.0.0
 pre-commit
 djhtml

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -25,3 +25,10 @@ def test_dc_base_template(client):
 def test_dc_base_naked_template(client):
     req = client.get("/test_dc_base_naked.html")
     assert req.status_code == 200
+
+
+def test_form_view(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"id_postcode" in resp.content
+    assert b"Heading Field" in resp.content

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -111,8 +111,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -11,10 +11,10 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from pathlib import Path
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
+BASE_DIR = Path(__file__).resolve(strict=True).parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
@@ -25,7 +25,7 @@ SECRET_KEY = "testing_only_s#=1z=a46wziq#k+@$3_xtt*t*rm5rk)gq3*-tw67+-%z6-x0^"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
@@ -55,7 +55,7 @@ ROOT_URLCONF = "tests.testapp.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/tests/testapp/templates/base.html
+++ b/tests/testapp/templates/base.html
@@ -1,0 +1,10 @@
+{% extends "dc_base.html" %}
+{% block site_menu %}
+    <nav>
+    <ul>
+        <li><a href="{% url "test_form" %}">Sample Form</a></li>
+        <li><a href="{% url "test_dc_base"%}">Test dc_base.html</a></li>
+        <li><a href="{% url "test_dc_base_naked" %}">dc_base_naked.html</a></li>
+    </ul>
+    </nav>
+{% endblock %}

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -17,13 +17,19 @@ from django.contrib import admin
 from django.urls import path
 from django.views.generic import TemplateView
 
+from dc_utils.views import SampleFormView
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path(
-        "test_dc_base.html", TemplateView.as_view(template_name="dc_base.html")
+        "test_dc_base.html",
+        TemplateView.as_view(template_name="dc_base.html"),
+        name="test_dc_base",
     ),
     path(
         "test_dc_base_naked.html",
         TemplateView.as_view(template_name="dc_base_naked.html"),
+        name="test_dc_base_naked",
     ),
+    path("", SampleFormView.as_view(), name="test_form"),
 ]


### PR DESCRIPTION
Closes #13, #28, https://github.com/DemocracyClub/dc_django_utils/issues/30

This work: 

- abstracts `GBPostcodeLookup` used in WDIV and WCIVF. 
- adds the logo text in accordance with the design system
- adds aria focus 
- adds a template to test form changes
- adds viewport and content tags to `site_meta`

👍 Forms tested in WDIV
