### PR TITLE
Hotfix/Match output filename with scss

### DIFF
--- a/dc_utils/settings/pipeline.py
+++ b/dc_utils/settings/pipeline.py
@@ -31,7 +31,7 @@ DEFAULT_PIPELINE = {
     "STYLESHEETS": {
         "styles": {
             "source_filenames": [],
-            "output_filename": "css/styles.css",
+            "output_filename": "scss/styles.css",
             "extra_context": {
                 "media": "screen,print",
             },


### PR DESCRIPTION
[This error ](https://app.circleci.com/pipelines/github/DemocracyClub/Website/1624/workflows/77d2f92f-49c3-47d8-99fa-54fac49eac2b/jobs/3609)led me to find the mismatch between `css/` in `dc_utils` and `scss/` in dependent repos. 

I've confirmed this fix solves the above error in https://github.com/DemocracyClub/Website/pull/608 