### PR TITLE
Pin js-min

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ install_requires =
     whitenoise == 5.2.0
     django-pipeline == 2.0.8
     libsass == 0.21.0
-    jsmin==3.0.0
+    jsmin<3.1
     django>=3.2,<4.2
     markdown
     pytest-django


### PR DESCRIPTION
EE deployment failed due to a conflict:

EE requires `jsmin==3.0.1` in production however `dc-django-utils 2.0.0 depends on jsmin==3.0.0`. 

This PR extend the range to `jsmin<3.1`