### PR TITLE
Hotfix/form errors

### DIFF
--- a/dc_utils/templates/dc_forms/form.html
+++ b/dc_utils/templates/dc_forms/form.html
@@ -13,7 +13,7 @@
 {% endfor %}
 
 {% for field in form.visible_fields %}
-    {% if field.errors %}<div class="ds-error">{% endif %}
+
     {% if field|is_dc_date_field %}
         {% include 'dc_forms/field_date.html' %}
     {% elif field|is_radio %}
@@ -27,6 +27,11 @@
     {% else %}
         {% include 'dc_forms/field.html' %}
     {% endif %}
-    {% if field.errors %}</div>{% endif %}
+    {% if field.errors %}
+        {% for error in field.errors %}
+            <div class="ds-error">
+                {{ error }}
+            </div>
+        {% endfor %}
+    {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1505

This work moves the error class so that it only encompasses the error itself and not also the form field. 

As seen on WCIVF for invalid submissions: 
<img width="979" alt="Screenshot 2023-02-14 at 1 48 20 PM" src="https://user-images.githubusercontent.com/7017118/218757062-2edf1393-cd97-4c97-a805-a1f3aeed4f16.png">
To center the form error in this use case, I've had to add `.ds-error {
    margin: 1rem auto;
}` to the class in the WCIVF stylesheet in a separate PR.  The same will need to be done in WDIV. 

Compared with a valid postcode that is not found: 

<img width="1016" alt="Screenshot 2023-02-14 at 1 42 35 PM" src="https://user-images.githubusercontent.com/7017118/218757834-5d74d8fe-0f0c-47fc-bb8a-f01b96cc4caa.png">








