### PR TITLE
Remove error from field date

### DIFF
--- a/dc_utils/templates/dc_forms/field_date.html
+++ b/dc_utils/templates/dc_forms/field_date.html
@@ -1,12 +1,5 @@
 <fieldset>
     <legend>{% if field.help_text %}{{ field.help_text }}{% else %}{{field.label}}{% endif %}</legend>
-    {% if field.errors %}
-        <div class="ds-error">
-            {% for error in field.errors %}
-                <span role="img" aria-label="Error">❌ {{ error }}</span>
-            {% endfor %}
-        </div>
-    {% endif %}
     <div class="ds-date">
         {{ field}}
     </div>


### PR DESCRIPTION
Similar to https://github.com/DemocracyClub/dc_django_utils/pull/49, this removes the error from the `feild_date.html` where it is now rendered from `dc_utils/templates/dc_forms/form.html`