### PR TITLE
Add default message blog with level tag

### DIFF
--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -21,6 +21,15 @@
                 <main id="main" tabindex="-1" class="ds-stack">
 
                     {% block messages %}
+                        {% if messages %}
+                            <aside class="ds-status" aria-label="Status">
+                                <ul class="ds-stack">
+                                    {% for message in messages %}
+                                        <li {% if message.tags %}class=" {{ message.tags }} ds-status-message ds-status-{{ message.level_tag }} " {% endif %}> {{ message }} </li>
+                                    {% endfor %}
+                                </ul>
+                            </aside>
+                        {% endif %}
                     {% endblock messages %}
 
                     {% block content %}


### PR DESCRIPTION
This change sets a default tag similar to what already exists in WDIV, which includes `level_tag` which dynamically raises the the appropriate colour status message. 