### PR TITLE
Accept Django >=3.2,<4.3

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@ black==22.10.0
 isort
 ipdb
 django-pipeline==2.0.8
-Django>=3.2,<4.2
+Django>=3.2,<4.3
 markdown
 django-localflavor==3.1
 setuptools==65.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ description = Django common utils and helpers for Democracy Club projects
 packages = find:
 include_package_data = true
 install_requires =
-    whitenoise == 5.2.0
+    whitenoise == 6.4.0
     django-pipeline == 2.0.8
     libsass == 0.22.0
     jsmin<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
     django-pipeline == 2.0.8
     libsass == 0.22.0
     jsmin<3.1
-    django>=3.2,<4.2
+    django>=3.2,<=4.2
     markdown
     pytest-django
     pytest


### PR DESCRIPTION
This change expands accepted Django versions to include `4.2` and includes a version bump to `6.4.0` for `whitenoise`