### PR TITLE
Match required installs to requirements 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
     django-pipeline == 2.0.8
     libsass == 0.22.0
     jsmin<3.1
-    django>=3.2,<=4.2
+    django>=3.2,<4.3
     markdown
     pytest-django
     pytest


### PR DESCRIPTION
This is a follow up to https://github.com/DemocracyClub/dc_django_utils/pull/55 to match the Django versionining in `setup.cfg` to requirements file.