### PR TITLE
Pin and downgrade setuptools to address deprecation error

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ django-pipeline==2.0.8
 Django>=3.2,<4.3
 markdown
 django-localflavor==3.1
-setuptools==65.5.1
+setuptools==58.2.0
 pre-commit
 djhtml
 


### PR DESCRIPTION
Ref https://stackoverflow.com/questions/73257839/setup-py-install-is-deprecated-warning-shows-up-every-time-i-open-a-terminal-i

I *think* the alternative to this downgrade is to refactor the setup config. Advice welcome on design choices that work best for projects using this functionality. 🏳️ 