### PR TITLE
Bump django-pipeline==2.1.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 black==22.10.0
 isort
 ipdb
-django-pipeline==2.0.8
+django-pipeline==2.1.0
 Django>=3.2,<4.3
 markdown
 django-localflavor==3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ packages = find:
 include_package_data = true
 install_requires =
     whitenoise == 6.4.0
-    django-pipeline == 2.0.8
+    django-pipeline == 2.1.0
     libsass == 0.22.0
     jsmin<3.1
     django>=3.2,<4.3


### PR DESCRIPTION
This change was needed to satisfy requirements in the EE Django 4.2.3 upgrade. Tested in EE. 