### PR TITLE
adds DSLinkWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ if settings.DEBUG:
 ### Add the following line with the [latest version](https://github.com/DemocracyClub/dc_django_utils/releases) to `requirements.txt':
 `git+https://github.com/DemocracyClub/dc_django_utils.git@[hash]`
 
+### Using the DS Link Widget 
+
+ The DS Link Widget in [filter_widgets](dc_utils/filter_widgets.py) extends the Link Widget from django-filter in order to customize its html. Your project will therefore need to have [django-filter](https://github.com/carltongibson/django-filter) already installed if you want to use it.
+
 ### Local Development
 Install the dev dependencies:
 

--- a/dc_utils/filter_widgets.py
+++ b/dc_utils/filter_widgets.py
@@ -1,0 +1,54 @@
+from urllib.parse import urlencode
+
+try:
+    from django_filters.widgets import LinkWidget
+except ImportError:
+    raise ImportError("Filter widgets requires Django-Filter to be installed")
+
+from django.utils.safestring import mark_safe
+from django.db.models import BLANK_CHOICE_DASH
+from django.utils.encoding import force_str
+
+__all__ = ("DSLinkWidget",)
+
+
+class DSLinkWidget(LinkWidget):
+    """
+    The django_filters LinkWidget doesn't allow iterating over choices in the template layer
+    to change the HTML wrapping the widget.
+
+    This breaks the way that Django *should* work, so we have to subclass
+    and alter the HTML in Python :/
+
+    https://github.com/carltongibson/django-filter/issues/880
+    """
+
+    def render(self, name, value, attrs=None, choices=(), renderer=None):
+        if not hasattr(self, "data"):
+            self.data = {}
+        if value is None:
+            value = ""
+        self.build_attrs(self.attrs, extra_attrs=attrs)
+        output = []
+        options = self.render_options(choices, [value], name)
+        if options:
+            output.append(options)
+        # output.append('</ul>')
+        return mark_safe("\n".join(output))
+
+    def render_option(self, name, selected_choices, option_value, option_label):
+        option_value = force_str(option_value)
+        if option_label == BLANK_CHOICE_DASH[0][1]:
+            option_label = "All"
+        data = self.data.copy()
+        data[name] = option_value
+        selected = data == self.data or option_value in selected_choices
+        try:
+            url = data.urlencode()
+        except AttributeError:
+            url = urlencode(data)
+        return self.option_string() % {
+            "attrs": selected and ' aria-current="true"' or "",
+            "query_string": url,
+            "label": force_str(option_label),
+        }


### PR DESCRIPTION
This PR adds the `DSLinkWidget `which is used in filters across multiple DC projects to `dc_django_utils `so that it can be imported from the package rather than duplicated every time.

`DSLinkWidget `extends `LinkWidget ` from `django_filter `so `django_filter `must already be installed on the project to use this widget or it will throw an error on the widget's import.

Successfully tested locally but would be good to get a 2nd confirmation!
