### PR TITLE
Logo repairs

### DIFF
--- a/dc_utils/context_processors.py
+++ b/dc_utils/context_processors.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 def dc_django_utils(request):
     return {
-        "SITE_LOGO_WIDTH": "100",
+        "SITE_LOGO_WIDTH": "80",
         "SITE_TITLE": getattr(settings, "SITE_TITLE", ""),
         "CANONICAL_URL": f"{request.scheme}://{request.get_host()}",
     }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ pytest-django
 pytest-mock
 pytest-flakes
 pytidylib
-https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
+https://github.com/DemocracyClub/design-system/archive/refs/tags/0.4.5.tar.gz
 whitenoise
 pysass
 jsmin<3.1


### PR DESCRIPTION
This change

- bumps the `design system` to v0.4.5
- reduces the default logo size to reduce white space on all device sizes
- make the footer logo appear centered

After

![Screenshot 2024-01-29 at 12 25 17 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/7409e703-06fd-4ca8-a688-6d8169f1506c)
![Screenshot 2024-01-29 at 12 25 23 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/8768eaa0-3748-4b6b-89d2-d017e2cb6ac5)
![Screenshot 2024-01-29 at 12 25 40 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/2389fe0b-3b97-4307-a5d1-01f1ae11fda9)
![Screenshot 2024-01-29 at 12 25 48 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/172d3e79-fe9e-42b7-a7cc-d95989937ff6)
