### PR TITLE
Hard code logo icon width

### DIFF
--- a/dc_utils/context_processors.py
+++ b/dc_utils/context_processors.py
@@ -3,7 +3,6 @@ from django.conf import settings
 
 def dc_django_utils(request):
     return {
-        "SITE_LOGO_WIDTH": "80",
         "SITE_TITLE": getattr(settings, "SITE_TITLE", ""),
         "CANONICAL_URL": f"{request.scheme}://{request.get_host()}",
     }

--- a/dc_utils/templates/404.html
+++ b/dc_utils/templates/404.html
@@ -12,7 +12,7 @@
             <header role="banner">
                 <div class="container">
                     <a href="/">
-                        <img src="{% if STATIC_URL %}{{ STATIC_URL }}{% endif %}/images/logo_icon.png" alt="{% if site_title %}{{ site_title }}{% endif %}" width="{{ SITE_LOGO_WIDTH|default:"100" }}">
+                        <img src="{% if STATIC_URL %}{{ STATIC_URL }}{% endif %}/images/logo_icon.svg" alt="{% if site_title %}{{ site_title }}{% endif %}" width="72">
                     </a>
                 </div>
             </header>

--- a/dc_utils/templates/500.html
+++ b/dc_utils/templates/500.html
@@ -12,7 +12,7 @@
             <header role="banner">
                 <div class="container">
                     <a href="/">
-                        <img src="{{ STATIC_URL }}/images/logo_icon.png" alt="{{ site_title }}" width="{{ SITE_LOGO_WIDTH|default:"100" }}">
+                        <img src="{{ STATIC_URL }}/images/logo_icon.svg" alt="{{ site_title }}" width="72">
                     </a>
                 </div>
             </header>

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -9,7 +9,7 @@
             {% block header_base %}
                 <header class="ds-header">
                     <a class="ds-logo" href="/">
-                        <img src="{% static 'images/logo_icon.svg' %}" alt="{{ SITE_TITLE }}" width="{{ SITE_LOGO_WIDTH|default:"100" }}">
+                        <img src="{% static 'images/logo_icon.svg' %}" alt="{{ SITE_TITLE }}" width="72">
                         <span>{{ SITE_TITLE }}</span>
                         {% block language_code %}{% endblock language_code %}
                     </a>


### PR DESCRIPTION
This change removes the `SITE_LOGO_WIDTH` so there is no conflict with styling in the design system. 

![Screenshot 2024-03-05 at 11 59 57 AM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/5bd3cc2a-c20d-4ce1-b454-fb150a401293)
