### PR TITLE
Hotfix/sample page fixup

### DIFF
--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -1,5 +1,6 @@
 {% extends "dc_base_naked.html" %}
 {% load static %}
+{% load i18n %}
 {% load pipeline %}
 {% block extra_site_css %}
     {% stylesheet 'styles' %}
@@ -45,7 +46,45 @@
             {% endblock main_base %}
 
             {% block footer_base %}
+                <footer class="ds-footer">
+                    <div class="ds-block-centered ds-text-centered ds-stack">
+                        {% block mailing_list %}
+                            <div class="ds-dark">
+                                <a class="ds-cta ds-cta-blue" href="https://mailinglist.democracyclub.org.uk/subscription/form">
+                                    Join our mailing list
+                                </a>
+                            </div>
+                        {% endblock mailing_list %}
+                        {% block footer_menu %}
+                        {% endblock footer_menu %}
+                        {% block footer_logo %}
+                            <div class="ds-copyright">
+                                <a class="ds-logo" href="/">
+                                    <img src="{% static 'images/logo_icon.svg' %}" width="72" alt="Democracy Club" />
+                                    <span class="ds-text-left">
+                                        democracy<br>club
+                                    </span>
+
+                                </a>
+                                {% now "Y" as current_year %}
+                                <p>{% blocktrans trimmed %}Copyright &copy; {{ current_year }}{% endblocktrans %}</p>
+                                <p>{% trans "Democracy Club Community Interest Company" %}</p>
+                                <p>{% blocktrans trimmed %}Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a>{% endblocktrans %}</p>
+                                <p class="ds-text-centered">
+                                    {% blocktrans trimmed %}
+                                        Democracy Club is a UK-based Community Interest Company that builds
+                                        the digital infrastructure needed for a 21st century democracy
+                                    {% endblocktrans %}
+                                </p>
+                            </div>
+                        {% endblock footer_logo %}
+                        {% block extra_footer_text %}
+                        {% endblock extra_footer_text %}
+                    </div>
+                </footer>
             {% endblock footer_base %}
+
+
         </div>
 
         {% block extra_site_js %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ pytest-django
 pytest-mock
 pytest-flakes
 pytidylib
-https://github.com/DemocracyClub/design-system/archive/refs/tags/0.4.5.tar.gz
+https://github.com/DemocracyClub/design-system/archive/refs/tags/0.4.6.tar.gz
 whitenoise
 pysass
 jsmin<3.1

--- a/tests/testapp/templates/base.html
+++ b/tests/testapp/templates/base.html
@@ -14,3 +14,14 @@
         </ul>
     </nav>
 {% endblock %}
+{% block footer_menu %}
+    <div class="ds-cluster-center">
+        <ul>
+            <li><a href="{% url "test_form" %}">Sample Form</a></li>
+            <li><a href="{% url "test_dc_base" %}">Test dc_base.html</a></li>
+            <li><a href="{% url "test_dc_base_naked" %}">dc_base_naked.html</a></li>
+            <li><a href="{% url "500" %}">500 error page</a></li>
+            <li><a href="{% url "404" %}">404 error page</a></li>
+        </ul>
+    </div>
+{% endblock footer_menu %}


### PR DESCRIPTION
After too much time spent unifying footers and logos, I'm proposing to bring the base footer elements back  into `dc_utils`. This edit will help test how design system changes affect all of the core components of base templates. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206863286902392