### PR TITLE
Additional testing tools and reformatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,18 @@ jobs:
           name: Black
           command: |
             black . --check
+      - run:
+          name: Curly Lint
+          command: | 
+            curlylint .
+      - run:
+          name: Ruff lint
+          command: |  
+            ruff check .
+      - run:
+          name: Ruff Format
+          command: | 
+            ruff format .
       - run: mkdir -p test-results
       - run:
           name: Pytest

--- a/dc_utils/forms.py
+++ b/dc_utils/forms.py
@@ -24,7 +24,6 @@ class DCHeaderField(forms.Field):
 
 
 class DCDateField(forms.MultiValueField):
-
     widget = widgets.DayMonthYearWidget
 
     def __init__(self, *args, **kwargs):
@@ -44,7 +43,7 @@ class DCDateField(forms.MultiValueField):
             fields=fields,
             require_all_fields=True,
             *args,
-            **kwargs
+            **kwargs,
         )
         self.field_class = "form-date"
 

--- a/dc_utils/templates/html_tester/all_elements.html
+++ b/dc_utils/templates/html_tester/all_elements.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 
-
 {% block content %}
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
 
@@ -301,12 +300,13 @@
                         <p><strong>Sample output:</strong> <samp>This is sample output from a computer program.</samp></p>
                         <h2>Pre-formatted text</h2>
                         <pre>P R E F O R M A T T E D T E X T
-! " # $ % &amp; ' ( ) * + , - . /
-0 1 2 3 4 5 6 7 8 9 : ; &lt; = &gt; ?
-@ A B C D E F G H I J K L M N O
-P Q R S T U V W X Y Z [ \ ] ^ _
-` a b c d e f g h i j k l m n o
-p q r s t u v w x y z { | } ~ </pre>
+                            ! " # $ % &amp; ' ( ) * + , - . /
+                            0 1 2 3 4 5 6 7 8 9 : ; &lt; = &gt; ?
+                            @ A B C D E F G H I J K L M N O
+                            P Q R S T U V W X Y Z [ \ ] ^ _
+                            ` a b c d e f g h i j k l m n o
+                            p q r s t u v w x y z { | } ~ 
+                        </pre>
                     </div>
 
                 </article>
@@ -519,10 +519,8 @@ p q r s t u v w x y z { | } ~ </pre>
 
                 </form>
             </section>
-
-
-        </section>
-
+        </main>
+    </section>
 
 
 {% endblock content %}

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 black==22.10.0
+curlylint
 isort
 ipdb
 django-pipeline==2.1.0
@@ -13,6 +14,7 @@ pytest
 pytest-django
 pytest-mock
 pytest-flakes
+pytest-ruff
 pytidylib
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.4.6.tar.gz
 whitenoise

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -124,8 +124,8 @@ STATICFILES_DIRS = (BASE_DIR / "assets",)
 
 
 from dc_utils.settings.pipeline import *  # noqa
-from dc_utils.settings.pipeline import get_pipeline_settings
-from dc_utils.settings.whitenoise import whitenoise_add_middleware
+from dc_utils.settings.pipeline import get_pipeline_settings  # noqa
+from dc_utils.settings.whitenoise import whitenoise_add_middleware  # noqa
 
 MIDDLEWARE = whitenoise_add_middleware(MIDDLEWARE)
 

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 from django.views.generic import TemplateView


### PR DESCRIPTION
This change came about while trying to debug an [error in WCIVF](https://app.circleci.com/pipelines/github/DemocracyClub/WhoCanIVoteFor/4017/workflows/83c599e1-9bdb-4034-8b69-92d5cd2acc29/jobs/11299?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) following installing the latest version of dc_utils. This change adds `curlylint` to CI and `pytest-ruff` to requirements to help reduce future errors and versions. 