### PR TITLE
Add missing translations

### DIFF
--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -16,8 +16,8 @@
                 <header class="ds-header">
                     <a class="ds-logo" href="/">
                         <img src="{% static 'images/logo_icon.svg' %}" alt="{{ SITE_TITLE }}" width="72">
-                        <span>{{ SITE_TITLE }}</span>
-                        {% block language_code %}{% endblock language_code %}
+                        <span>{{ SITE_TITLE }}{% block language_code %}{% endblock language_code %}</span>
+
                     </a>
                     {% block site_menu %}{% endblock site_menu %}
                 </header>
@@ -51,7 +51,7 @@
                         {% block mailing_list %}
                             <div class="ds-dark">
                                 <a class="ds-cta ds-cta-blue" href="https://mailinglist.democracyclub.org.uk/subscription/form">
-                                    Join our mailing list
+                                    {% trans "Join our mailing list" %}
                                 </a>
                             </div>
                         {% endblock mailing_list %}
@@ -62,7 +62,7 @@
                                 <a class="ds-logo" href="/">
                                     <img src="{% static 'images/logo_icon.svg' %}" width="72" alt="Democracy Club" />
                                     <span class="ds-text-left">
-                                        democracy<br>club
+                                        {% trans "democracy"%}<br>{% trans "club" %}
                                     </span>
 
                                 </a>

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -59,7 +59,7 @@
                         {% endblock footer_menu %}
                         {% block footer_logo %}
                             <div class="ds-copyright">
-                                <a class="ds-logo" href="/">
+                                <a class="ds-logo" href="https://democracyclub.org.uk/">
                                     <img src="{% static 'images/logo_icon.svg' %}" width="72" alt="Democracy Club" />
                                     <span class="ds-text-left">
                                         {% trans "democracy"%}<br>{% trans "club" %}

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -72,8 +72,7 @@
                                 <p>{% blocktrans trimmed %}Company No: <a href="https://beta.companieshouse.gov.uk/company/09461226">09461226</a>{% endblocktrans %}</p>
                                 <p class="ds-text-centered">
                                     {% blocktrans trimmed %}
-                                        Democracy Club is a UK-based Community Interest Company that builds
-                                        the digital infrastructure needed for a 21st century democracy
+                                        Building digital infrastructure for a 21st century democracy.
                                     {% endblocktrans %}
                                 </p>
                             </div>


### PR DESCRIPTION
This work started off with the aim of adding the ability to generate Welsh translations (hence the branch name) for footer content that lives here, but this was fixed in https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1792

So instead, this PR simply: 

- adds translation tags where they are missing
- updates the tagline per Will's suggestion
- adds the DC website url to the footer logo/
![Screenshot 2024-04-04 at 4 48 26 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/726fd112-583a-4d14-853b-d43059780a1f)
![Screenshot 2024-04-04 at 4 49 51 PM](https://github.com/DemocracyClub/dc_django_utils/assets/7017118/e0e4deaa-b7ec-4e02-bce0-c54f4ecbbbdf)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206157829306101
  - https://app.asana.com/0/0/1206929626417181
  - https://app.asana.com/0/0/1206929626417185