### PR TITLE
Hotfix/sha1 design system 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 	"pytest-flakes",
 	"pytest-ruff",
 	"pytidylib",
-	"dc-design-system @ https://github.com/DemocracyClub/design-system/archive/0.5.0.zip#sha1=8450de8c30f16539d0619df8fcc9106f4ab905e7",
+	"dc-design-system @ https://github.com/DemocracyClub/design-system/archive/0.5.0.zip",
 	"whitenoise",
 	"pysass",
 	"jsmin<3.1",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ pytest-mock
 pytest-flakes
 pytest-ruff
 pytidylib
-https://github.com/DemocracyClub/design-system/archive/0.5.0.zip#sha1=8450de8c30f16539d0619df8fcc9106f4ab905e7
+https://github.com/DemocracyClub/design-system/archive/0.5.0.zip
 whitenoise
 pysass
 jsmin<3.1


### PR DESCRIPTION
There is a version conflict when installing the current version of dc_utils into WCIVF, stemming from the design system and the addition of SHA1 in requirements. The SHA1 may be needed for pypi, however, this change is a temp move to unblock https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1792