### PR TITLE
Reformat design system install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 	"pytest-flakes",
 	"pytest-ruff",
 	"pytidylib",
-	"dc-design-system @ git+https://github.com/DemocracyClub/design-system@0.5.0",
+	"dc-design-system @ git+https://github.com/DemocracyClub/design-system.git@0.5.0",
 	"whitenoise",
 	"pysass",
 	"jsmin<3.1",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,8 @@ pytest-mock
 pytest-flakes
 pytest-ruff
 pytidylib
-dc-design-system @ git+https://github.com/DemocracyClub/design-system@0.5.0
+https://github.com/DemocracyClub/design-system/archive/refs/tags/0.5.0.tar.gz
+
 whitenoise
 pysass
 jsmin<3.1


### PR DESCRIPTION
Version 4.0.0 includes an incorrect sha1 which has led to dependency conflicts upstream in WCIVF. Although we may need an sha1 for pypi, I'm temporarily removing this to unblock the translation work on WCIVF. 