### PR TITLE
Use s3 url for logo

### DIFF
--- a/dc_utils/templates/404.html
+++ b/dc_utils/templates/404.html
@@ -12,7 +12,7 @@
             <header role="banner">
                 <div class="container">
                     <a href="/">
-                        <img src="{% if STATIC_URL %}{{ STATIC_URL }}{% endif %}/images/logo_icon.svg" alt="{% if site_title %}{{ site_title }} logo{% endif %}" width="72">
+                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="{% if site_title %}{{ site_title }} logo{% endif %}" width="72">
                     </a>
                 </div>
             </header>

--- a/dc_utils/templates/500.html
+++ b/dc_utils/templates/500.html
@@ -1,3 +1,4 @@
+{% extends "dc_base_naked.html" %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -12,7 +13,7 @@
             <header role="banner">
                 <div class="container">
                     <a href="/">
-                        <img src="{{ STATIC_URL }}/images/logo_icon.svg" alt="Democracy Club logo" width="72">
+                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
                     </a>
                 </div>
             </header>

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -15,7 +15,7 @@
             {% block header_base %}
                 <header class="ds-header">
                     <a class="ds-logo" href="/">
-                        <img src="{% static 'images/logo_icon.svg' %}" alt="Democracy Club logo" width="72">
+                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
                         <span>{{ SITE_TITLE }}{% block language_code %}{% endblock language_code %}</span>
                     </a>
                     {% block site_menu %}{% endblock site_menu %}

--- a/dc_utils/templates/dc_base_naked.html
+++ b/dc_utils/templates/dc_base_naked.html
@@ -19,7 +19,7 @@
         {% block site_meta %}
 
             {% block site_icons %}
-                <link rel="shortcut icon" href="{% static 'images/logo_icon.svg' %}">
+                <link rel="shortcut icon" href="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg">
                 <link rel="apple-touch-icon" sizes="180x180" href="{% static 'icons/apple-touch-icon.png' %}">
                 <link rel="icon" type="image/png" href="{% static 'icons/favicon-32x32.png' %}" sizes="32x32">
                 <link rel="icon" type="image/png" href="{% static 'icons/favicon-16x16.png' %}" sizes="16x16">


### PR DESCRIPTION
This work replaces the static url with a s3 url for logo on error pages. 

<img width="933" alt="Screenshot 2024-05-18 at 6 11 53 PM" src="https://github.com/DemocracyClub/dc_django_utils/assets/7017118/2dcb5dfb-9e6b-4199-96e4-55bf400cb9c7">
