### PR TITLE
Only include deps that are required at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,27 +7,16 @@ authors = [{name = "Sym Roe"}, {name = "Virginia Dooley"}]
 
 dependencies = [
 	"django>=3.2,<4.3",
-	"black", 
-	"curlylint",
-	"isort",
-	"ipdb",
 	"django-pipeline==3.0.0",
 	"markdown",
 	"django-localflavor==4.0",
 	"setuptools==69.2.0",
-	"ruff",
-	"pre-commit",
-	"djhtml",
-	"pytest",
-	"pytest-django",
-	"pytest-mock",
-	"pytest-flakes",
-	"pytest-ruff",
-	"pytidylib",
 	"whitenoise",
 	"pysass",
 	"jsmin<3.1",
 ]
+
+
 
 [project.urls]
 Homepage = "https://github.com/DemocracyClub/dc_django_utils"


### PR DESCRIPTION
WCIVF has exceeded the storage allowance for AWS so this change is part of an effort to free up storage on prod.