### PR TITLE
Use static CSS for error pages

### DIFF
--- a/dc_utils/templates/404.html
+++ b/dc_utils/templates/404.html
@@ -3,26 +3,28 @@
     <head>
         <meta charset="utf-8">
         <title>
-            Page Not found
+            Page not found
         </title>
+        <link rel="stylesheet" href="http://dc-shared-frontend-assets.s3-website.eu-west-2.amazonaws.com/styles.css">
     </head>
     <body class="ds-width-full">
         <div class="ds-page">
             <p><a class="ds-skip-link" href="#main">skip to content</a></p>
-            <header role="banner">
+            <header class="ds-header">
                 <div class="container">
-                    <a href="/">
-                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="{% if site_title %}{{ site_title }} logo{% endif %}" width="72">
+                    <a class="ds-logo" href="/">
+                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
+                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
                     </a>
                 </div>
             </header>
             <main id="main" tabindex="-1" class="ds-stack">
                 <div class="ds-card">
-                    <h2>404</h2>
-                    <p>Sorry, we can't find the page you were looking for.</p>
-                    <p>Try going <a href="/">going to the home page and starting from there</a>.</p>
-                    <p>If you think we've made a mistake, please
-                        <a href="https://democracyclub.org.uk/contact/">contact us</a>.</p>
+                    <h1>404: Page not found</h1>
+                    <p>It looks like the page you're trying to access can't be found.</p>
+                    <p>If you think this is a mistake, please
+                        <a href="https://democracyclub.org.uk/contact/">contact us</a>.
+                    </p>
                 </div>
             </main>
         </div>

--- a/dc_utils/templates/500.html
+++ b/dc_utils/templates/500.html
@@ -1,4 +1,3 @@
-{% extends "dc_base_naked.html" %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -6,14 +5,17 @@
         <title>
             Server Error
         </title>
+        <link rel="stylesheet" href="http://dc-shared-frontend-assets.s3-website.eu-west-2.amazonaws.com/styles.css">
+
     </head>
     <body class="ds-width-full">
         <div class="ds-page">
             <p><a class="ds-skip-link" href="#main">skip to content</a></p>
-            <header role="banner">
+            <header class="ds-header">
                 <div class="container">
-                    <a href="/">
+                    <a class="ds-logo" href="/">
                         <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
+                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
                     </a>
                 </div>
             </header>

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -16,7 +16,7 @@
                     <a class="ds-logo" href="/">
                         <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg"
                              alt="Democracy Club logo" width="{{ SITE_LOGO_WIDTH }}">
-                        <span>{{ SITE_TITLE }}{% block language_code %}{% endblock language_code %}</span>
+                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
                     </a>
                     {% block site_menu %}{% endblock site_menu %}
                 </header>


### PR DESCRIPTION
This means the error pages don't rely on a pipeline to work in order to show with CSS


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208685143004192