### PR TITLE
Remove page param in DSLinkFilter

### DIFF
--- a/dc_utils/filter_widgets.py
+++ b/dc_utils/filter_widgets.py
@@ -28,6 +28,8 @@ class DSLinkWidget(LinkWidget):
             self.data = {}
         if value is None:
             value = ""
+        self.data = self.data.copy()
+        self.data.pop("page", None)
         self.build_attrs(self.attrs, extra_attrs=attrs)
         output = []
         options = self.render_options(choices, [value], name)


### PR DESCRIPTION
At the moment, we copy all params from the querystring and edit them based on the filter value. 

This is great for chaining more than one filter, but `page` is a special case: there is no value in deep-linking to page `n` of a newly filtered queryset. If you are adding (or removing) a filter, you will want to see page 1, always.
