### PR TITLE
wrap header and footer in data-nosnippet

### DIFF
--- a/dc_utils/templates/404.html
+++ b/dc_utils/templates/404.html
@@ -9,15 +9,17 @@
     </head>
     <body class="ds-width-full">
         <div class="ds-page">
-            <p><a class="ds-skip-link" href="#main">skip to content</a></p>
-            <header class="ds-header">
-                <div class="container">
-                    <a class="ds-logo" href="/">
-                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
-                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
-                    </a>
-                </div>
-            </header>
+            <div data-nosnippet>
+                <p><a class="ds-skip-link" href="#main">skip to content</a></p>
+                <header class="ds-header">
+                    <div class="container">
+                        <a class="ds-logo" href="/">
+                            <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
+                            <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
+                        </a>
+                    </div>
+                </header>
+            </div>
             <main id="main" tabindex="-1" class="ds-stack">
                 <div class="ds-card">
                     <h1>404: Page not found</h1>

--- a/dc_utils/templates/500.html
+++ b/dc_utils/templates/500.html
@@ -10,15 +10,17 @@
     </head>
     <body class="ds-width-full">
         <div class="ds-page">
-            <p><a class="ds-skip-link" href="#main">skip to content</a></p>
-            <header class="ds-header">
-                <div class="container">
-                    <a class="ds-logo" href="/">
-                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
-                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
-                    </a>
-                </div>
-            </header>
+            <div data-nosnippet>
+                <p><a class="ds-skip-link" href="#main">skip to content</a></p>
+                <header class="ds-header">
+                    <div class="container">
+                        <a class="ds-logo" href="/">
+                            <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg" alt="Democracy Club logo" width="72">
+                            <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
+                        </a>
+                    </div>
+                </header>
+            </div>
             <main id="main" tabindex="-1" class="ds-stack">
                 <div class="ds-card">
                     <h1>500 server error</h1>

--- a/dc_utils/templates/dc_base.html
+++ b/dc_utils/templates/dc_base.html
@@ -9,18 +9,20 @@
 {% block body_raw %}
     <body {% block body_attrs %}class="ds-width-full"{% endblock body_attrs %}>
         <div class="ds-page">
-            <a class="ds-skip-link" href="#main">skip to content</a>
-            {% block base_language_menu %}{% endblock base_language_menu %}
-            {% block header_base %}
-                <header class="ds-header">
-                    <a class="ds-logo" href="/">
-                        <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg"
-                             alt="Democracy Club logo" width="{{ SITE_LOGO_WIDTH }}">
-                        <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
-                    </a>
-                    {% block site_menu %}{% endblock site_menu %}
-                </header>
-            {% endblock header_base %}
+            <div data-nosnippet>
+                <a class="ds-skip-link" href="#main">skip to content</a>
+                {% block base_language_menu %}{% endblock base_language_menu %}
+                {% block header_base %}
+                    <header class="ds-header">
+                        <a class="ds-logo" href="/">
+                            <img src="https://dc-shared-frontend-assets.s3.eu-west-2.amazonaws.com/images/logo_icon.svg"
+                                 alt="Democracy Club logo" width="{{ SITE_LOGO_WIDTH }}">
+                            <span>{{ SITE_TITLE|default:"democracy<br>club" }}{% block language_code %}{% endblock language_code %}</span>
+                        </a>
+                        {% block site_menu %}{% endblock site_menu %}
+                    </header>
+                {% endblock header_base %}
+            </div>
 
             {% block main_base %}
                 <main id="main" tabindex="-1" class="ds-stack">
@@ -44,41 +46,43 @@
                 </main>
             {% endblock main_base %}
 
-            {% block footer_base %}
-                <footer class="ds-footer">
-                    {% block footer_logo %}
+            <div data-nosnippet>
+                {% block footer_base %}
+                    <footer class="ds-footer">
+                        {% block footer_logo %}
                         {# Note we need both an inline style and width here: with CSS the design system #}
                         {# sets the width to 100% and without the default is 100% #}
-                        <img src="{% static 'images/logo_icon.svg' %}" style="width:{{ SITE_LOGO_WIDTH }}px" width="{{ SITE_LOGO_WIDTH }}"
-                             alt="Democracy Club logo"/>{% endblock footer_logo %}
-                    {% block footer_menu %}{% endblock footer_menu %}
+                            <img src="{% static 'images/logo_icon.svg' %}" style="width:{{ SITE_LOGO_WIDTH }}px" width="{{ SITE_LOGO_WIDTH }}"
+                                 alt="Democracy Club logo"/>{% endblock footer_logo %}
+                        {% block footer_menu %}{% endblock footer_menu %}
 
-                    {% block mailing_list %}
-                        <div class="ds-dark">
-                            <a class="ds-cta ds-cta-blue" href="https://mailinglist.democracyclub.org.uk/subscription/form">
+                        {% block mailing_list %}
+                            <div class="ds-dark">
+                                <a class="ds-cta ds-cta-blue" href="https://mailinglist.democracyclub.org.uk/subscription/form">
+                                    {% if LANGUAGE_CODE == 'cy' %}
+                                        Ymunwch â'n rhestr bostio
+                                    {% else %}
+                                        Join our mailing list
+                                    {% endif %}
+                                </a>
+                            </div>
+                        {% endblock mailing_list %}
+                        <div class="ds-copyright">
+                            {% block footer_copyright %}
                                 {% if LANGUAGE_CODE == 'cy' %}
-                                    Ymunwch â'n rhestr bostio
+                                    {% include 'includes/cy-footer-copyright.html' %}
                                 {% else %}
-                                    Join our mailing list
+                                    {% include 'includes/en-footer-copyright.html' %}
                                 {% endif %}
-                            </a>
+                            {% endblock %}
+                            {% block extra_footer_copyright_text %}
+                            {% endblock extra_footer_copyright_text %}
                         </div>
-                    {% endblock mailing_list %}
-                    <div class="ds-copyright">
-                        {% block footer_copyright %}
-                            {% if LANGUAGE_CODE == 'cy' %}
-                                {% include 'includes/cy-footer-copyright.html' %}
-                            {% else %}
-                                {% include 'includes/en-footer-copyright.html' %}
-                            {% endif %}
-                        {% endblock %}
-                        {% block extra_footer_copyright_text %}
-                        {% endblock extra_footer_copyright_text %}
-                    </div>
 
 
-                </footer>
-            {% endblock footer_base %}
+                    </footer>
+                {% endblock footer_base %}
+            </div>
         </div>
         {% block extra_site_js %}
         {% endblock extra_site_js %}


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210134603328600?focus=true

This should fix this issue that Peter flagged:

![Screenshot_14-8-2025_131647_www google com](https://github.com/user-attachments/assets/ae31a0af-c4c3-4f48-813d-dcef55be6dce)

A few notes:

- `data-nosnippet` can only be a property of a `<div>`, `<span>`, or `<section>` tag. See https://developers.google.com/search/docs/crawling-indexing/special-tags#data-nosnippet
so I've wrapped these whole sections in a container `<div>`
- I've put the `<div data-nosnippet>` outside the blocks so if we customise these blocks in client apps the whole thing remains in a `<div data-nosnippet>`
- Next step will be to do a dc_django_utils release and upgrade client apps