### PR TITLE
Fix label attribute formatting in field.html

### DIFF
--- a/dc_utils/templates/dc_forms/field.html
+++ b/dc_utils/templates/dc_forms/field.html
@@ -3,7 +3,7 @@
     {% if field|is_heading %}
         <h2>{{ field.label }}</h2>
     {% else %}
-        <label class="{{ classes.label }} {% if field.field.required %}aria-required="true"{% endif %}" for="{{field.auto_id}}">
+        <label class="{{ classes.label }}" {% if field.field.required %}aria-required="true"{% endif %} for="{{field.auto_id}}">
             {{ field.label }}
             {% if field.help_text %}
                 <small>{{ field.help_text }}</small>


### PR DESCRIPTION
Currently `|dc_form` filter renders invalid markup e.g:

```html
<label class=" aria-required="true"" for="id_postcode">
```

This PR fixes it